### PR TITLE
chore: bump puya dependency versions

### DIFF
--- a/examples/production/package.json
+++ b/examples/production/package.json
@@ -20,13 +20,13 @@
     "npm": ">=9.0"
   },
   "dependencies": {
-    "@algorandfoundation/algorand-typescript": "^1.0.0-beta.6"
+    "@algorandfoundation/algorand-typescript": "^1.0.0-beta.16"
   },
   "devDependencies": {
     "@algorandfoundation/algokit-client-generator": "^4.0.6",
     "@algorandfoundation/algokit-utils": "^8.0.3",
     "@algorandfoundation/algokit-utils-debug": "^1.0.3",
-    "@algorandfoundation/puya-ts": "^1.0.0-beta.10",
+    "@algorandfoundation/puya-ts": "^1.0.0-beta.23",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node20": "^20.1.4",
     "algosdk": "^3.0.0",
@@ -37,7 +37,7 @@
     "typescript-eslint": "^8.19.1",
     "prettier": "^3.4.2",
     "ts-node-dev": "^2.0.0",
-    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.8",
+    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.19",
     "vitest": "^2.1.8",
     "@vitest/coverage-v8": "^2.1.8",
     "typescript": "^5.7.3"

--- a/examples/production/vitest.config.mts
+++ b/examples/production/vitest.config.mts
@@ -1,4 +1,4 @@
-import { puyaTsTransformer } from '@algorandfoundation/algorand-typescript-testing/test-transformer'
+import { puyaTsTransformer } from '@algorandfoundation/algorand-typescript-testing/vitest-transformer'
 import typescript from '@rollup/plugin-typescript'
 import { defineConfig } from 'vitest/config'
 

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -14,13 +14,13 @@
     "npm": ">=9.0"
   },
   "dependencies": {
-    "@algorandfoundation/algorand-typescript": "^1.0.0-beta.6"
+    "@algorandfoundation/algorand-typescript": "^1.0.0-beta.16"
   },
   "devDependencies": {
     "@algorandfoundation/algokit-client-generator": "^4.0.6",
     "@algorandfoundation/algokit-utils": "^8.0.3",
     "@algorandfoundation/algokit-utils-debug": "^1.0.3",
-    "@algorandfoundation/puya-ts": "^1.0.0-beta.10",
+    "@algorandfoundation/puya-ts": "^1.0.0-beta.23",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node20": "^20.1.4",
     "algosdk": "^3.0.0",

--- a/template_content/package.json.jinja
+++ b/template_content/package.json.jinja
@@ -28,13 +28,13 @@
     "npm": ">=9.0"
   },
   "dependencies": {
-    "@algorandfoundation/algorand-typescript": "^1.0.0-beta.6"
+    "@algorandfoundation/algorand-typescript": "^1.0.0-beta.16"
   },
   "devDependencies": {
     "@algorandfoundation/algokit-client-generator": "^4.0.6",
     "@algorandfoundation/algokit-utils": "^8.0.3",
     "@algorandfoundation/algokit-utils-debug": "^1.0.3",
-    "@algorandfoundation/puya-ts": "^1.0.0-beta.10",
+    "@algorandfoundation/puya-ts": "^1.0.0-beta.23",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node20": "^20.1.4",
     "algosdk": "^3.0.0",
@@ -52,7 +52,7 @@
     {%- endif %}
     "ts-node-dev": "^2.0.0",
     {%- if use_vitest  %}
-    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.8",
+    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.19",
     "vitest": "^2.1.8",
     "@vitest/coverage-v8": "^2.1.8",
     {%- endif %}

--- a/template_content/{% if use_vitest %}vitest.config.mts{% endif %}
+++ b/template_content/{% if use_vitest %}vitest.config.mts{% endif %}
@@ -1,4 +1,4 @@
-import { puyaTsTransformer } from '@algorandfoundation/algorand-typescript-testing/test-transformer'
+import { puyaTsTransformer } from '@algorandfoundation/algorand-typescript-testing/vitest-transformer'
 import typescript from '@rollup/plugin-typescript'
 import { defineConfig } from 'vitest/config'
 


### PR DESCRIPTION
## Proposed Changes

- update `@algorandfoundation/algorand-typescript` package version to `^1.0.0-beta.16` 
- update `@algorandfoundation/algorand-typescript-testing` package version to `^1.0.0-beta.19` 
- update `@algorandfoundation/puya-ts` package version to `^1.0.0-beta.23` 

- update `puyaTsTransformer` import to use `vitest-transformer` namespace
