### PR TITLE
chore: update template to use puya-ts with binary puya backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,7 @@
 
 This template provides a beta template for developing and deploying [Algorand TypeScript](https://github.com/algorandfoundation/puya-ts) smart contracts.
 
-~~To use it [install AlgoKit](https://github.com/algorandfoundation/algokit-cli#readme) and then either pass in `-t typescript` to `algokit init` or select the `typescript` template.~~
-
-To use it run:
-```
-algokit init --template-url https://github.com/algorandfoundation/algokit-typescript-template --UNSAFE-SECURITY-accept-template-url
-```
+To use it [install AlgoKit](https://github.com/algorandfoundation/algokit-cli#readme) and then either pass in `-t typescript` to `algokit init` or select the `typescript` template.
 
 This is one of the official templates used by AlgoKit to initialize an Algorand smart contract project. It's a [Copier template](https://copier.readthedocs.io/en/stable/).
 

--- a/examples/production/.algokit.toml
+++ b/examples/production/.algokit.toml
@@ -1,5 +1,5 @@
 [algokit]
-min_version = "v2.0.0"
+min_version = "v2.6.0"
 
 [generate.smart-contract]
 description = "Generate a new smart contract for existing project"

--- a/examples/production/.github/workflows/production-ci.yaml
+++ b/examples/production/.github/workflows/production-ci.yaml
@@ -26,9 +26,6 @@ jobs:
       - name: Install algokit
         run: pipx install algokit
 
-      - name: Install Puya compiler
-        run: pipx install puyapy
-
       - name: Start LocalNet
         run: algokit localnet start
 

--- a/examples/production/README.md
+++ b/examples/production/README.md
@@ -25,7 +25,6 @@ Ensure the following pre-requisites are installed and properly configured:
 
 - **Docker**: Required for running a local Algorand network.
 - **AlgoKit CLI**: Essential for project setup and operations. Verify installation with `algokit --version`, expecting `2.5.0` or later.
-- **Puya Compiler**: Can be installed from PyPi by running `pipx install puyapy`. Verify installation with `puyapy --version`, expecting `4.4.4` or later.
 
 #### 3. Bootstrap Your Local Environment
 

--- a/examples/production/package.json
+++ b/examples/production/package.json
@@ -26,7 +26,7 @@
     "@algorandfoundation/algokit-client-generator": "^4.0.9",
     "@algorandfoundation/algokit-utils": "^8.2.2",
     "@algorandfoundation/algokit-utils-debug": "^1.0.3",
-    "@algorandfoundation/puya-ts": "^1.0.0-beta.47",
+    "@algorandfoundation/puya-ts": "^1.0.0-beta.50",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
     "algosdk": "^3.0.0",
@@ -37,7 +37,7 @@
     "typescript-eslint": "^8.19.1",
     "prettier": "^3.4.2",
     "ts-node-dev": "^2.0.0",
-    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.29",
+    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.30",
     "vitest": "^2.1.8",
     "@vitest/coverage-v8": "^2.1.8",
     "typescript": "^5.7.3"

--- a/examples/production/package.json
+++ b/examples/production/package.json
@@ -4,7 +4,7 @@
   "description": "Smart contract deployer",
   "main": "smart_contracts/index.ts",
   "scripts": {
-    "build": "puya-ts build smart_contracts --output-source-map --out-dir artifacts && algokit generate client smart_contracts/artifacts --output {app_spec_dir}/{contract_name}Client.ts",
+    "build": "algokit compile ts smart_contracts --output-source-map --out-dir artifacts && algokit generate client smart_contracts/artifacts --output {app_spec_dir}/{contract_name}Client.ts",
     "deploy": "ts-node-dev --transpile-only --watch .env -r dotenv/config smart_contracts/index.ts",
     "deploy:ci": "ts-node --transpile-only -r dotenv/config smart_contracts/index.ts",
     "lint": "eslint smart_contracts",
@@ -20,13 +20,13 @@
     "npm": ">=9.0"
   },
   "dependencies": {
-    "@algorandfoundation/algorand-typescript": "^1.0.0-beta.20"
+    "@algorandfoundation/algorand-typescript": "^1.0.0-beta.25"
   },
   "devDependencies": {
-    "@algorandfoundation/algokit-client-generator": "^4.0.8",
-    "@algorandfoundation/algokit-utils": "^8.2.1",
+    "@algorandfoundation/algokit-client-generator": "^4.0.9",
+    "@algorandfoundation/algokit-utils": "^8.2.2",
     "@algorandfoundation/algokit-utils-debug": "^1.0.3",
-    "@algorandfoundation/puya-ts": "^1.0.0-beta.34",
+    "@algorandfoundation/puya-ts": "^1.0.0-beta.47",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
     "algosdk": "^3.0.0",
@@ -37,7 +37,7 @@
     "typescript-eslint": "^8.19.1",
     "prettier": "^3.4.2",
     "ts-node-dev": "^2.0.0",
-    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.27",
+    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.29",
     "vitest": "^2.1.8",
     "@vitest/coverage-v8": "^2.1.8",
     "typescript": "^5.7.3"

--- a/examples/starter/.algokit.toml
+++ b/examples/starter/.algokit.toml
@@ -1,5 +1,5 @@
 [algokit]
-min_version = "v2.0.0"
+min_version = "v2.6.0"
 
 [generate.smart-contract]
 description = "Generate a new smart contract for existing project"

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -23,7 +23,6 @@ Ensure the following pre-requisites are installed and properly configured:
 
 - **Docker**: Required for running a local Algorand network.
 - **AlgoKit CLI**: Essential for project setup and operations. Verify installation with `algokit --version`, expecting `2.5.0` or later.
-- **Puya Compiler**: Can be installed from PyPi by running `pipx install puyapy`. Verify installation with `puyapy --version`, expecting `4.4.4` or later.
 
 #### 3. Bootstrap Your Local Environment
 Run the following commands within the project folder:

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -20,7 +20,7 @@
     "@algorandfoundation/algokit-client-generator": "^4.0.9",
     "@algorandfoundation/algokit-utils": "^8.2.2",
     "@algorandfoundation/algokit-utils-debug": "^1.0.3",
-    "@algorandfoundation/puya-ts": "^1.0.0-beta.47",
+    "@algorandfoundation/puya-ts": "^1.0.0-beta.50",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
     "algosdk": "^3.0.0",

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -4,7 +4,7 @@
   "description": "Smart contract deployer",
   "main": "smart_contracts/index.ts",
   "scripts": {
-    "build": "puya-ts build smart_contracts --output-source-map --out-dir artifacts && algokit generate client smart_contracts/artifacts --output {app_spec_dir}/{contract_name}Client.ts",
+    "build": "algokit compile ts smart_contracts --output-source-map --out-dir artifacts && algokit generate client smart_contracts/artifacts --output {app_spec_dir}/{contract_name}Client.ts",
     "deploy": "ts-node-dev --transpile-only --watch .env -r dotenv/config smart_contracts/index.ts",
     "deploy:ci": "ts-node --transpile-only -r dotenv/config smart_contracts/index.ts",
     "check-types": "tsc --noEmit"
@@ -14,13 +14,13 @@
     "npm": ">=9.0"
   },
   "dependencies": {
-    "@algorandfoundation/algorand-typescript": "^1.0.0-beta.20"
+    "@algorandfoundation/algorand-typescript": "^1.0.0-beta.25"
   },
   "devDependencies": {
-    "@algorandfoundation/algokit-client-generator": "^4.0.8",
-    "@algorandfoundation/algokit-utils": "^8.2.1",
+    "@algorandfoundation/algokit-client-generator": "^4.0.9",
+    "@algorandfoundation/algokit-utils": "^8.2.2",
     "@algorandfoundation/algokit-utils-debug": "^1.0.3",
-    "@algorandfoundation/puya-ts": "^1.0.0-beta.34",
+    "@algorandfoundation/puya-ts": "^1.0.0-beta.47",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
     "algosdk": "^3.0.0",

--- a/poetry.lock
+++ b/poetry.lock
@@ -201,30 +201,6 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
-name = "cattrs"
-version = "24.1.2"
-description = "Composable complex class support for attrs and dataclasses."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "cattrs-24.1.2-py3-none-any.whl", hash = "sha256:67c7495b760168d931a10233f979b28dc04daf853b30752246f4f8471c6d68d0"},
-    {file = "cattrs-24.1.2.tar.gz", hash = "sha256:8028cfe1ff5382df59dd36474a86e02d817b06eaf8af84555441bac915d2ef85"},
-]
-
-[package.dependencies]
-attrs = ">=23.1.0"
-
-[package.extras]
-bson = ["pymongo (>=4.4.0)"]
-cbor2 = ["cbor2 (>=5.4.6)"]
-msgpack = ["msgpack (>=1.0.5)"]
-msgspec = ["msgspec (>=0.18.5)"]
-orjson = ["orjson (>=3.9.2)"]
-pyyaml = ["pyyaml (>=6.0)"]
-tomlkit = ["tomlkit (>=0.11.8)"]
-ujson = ["ujson (>=5.7.0)"]
-
-[[package]]
 name = "cfgv"
 version = "3.4.0"
 description = "Validate configuration and produce human readable error messages."
@@ -269,17 +245,6 @@ python-versions = "*"
 files = [
     {file = "distlib-0.3.8-py2.py3-none-any.whl", hash = "sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784"},
     {file = "distlib-0.3.8.tar.gz", hash = "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"},
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.16"
-description = "Parse Python docstrings in reST, Google and Numpydoc format"
-optional = false
-python-versions = ">=3.6,<4.0"
-files = [
-    {file = "docstring_parser-0.16-py3-none-any.whl", hash = "sha256:bf0a1387354d3691d102edef7ec124f219ef639982d096e26e3b60aeffa90637"},
-    {file = "docstring_parser-0.16.tar.gz", hash = "sha256:538beabd0af1e2db0146b6bd3caa526c35a34d61af9fd2887f3a8a27a739aa6e"},
 ]
 
 [[package]]
@@ -437,17 +402,6 @@ python-versions = ">=3.5"
 files = [
     {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
     {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
-]
-
-[[package]]
-name = "immutabledict"
-version = "4.2.1"
-description = "Immutable wrapper around dictionaries (a fork of frozendict)"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "immutabledict-4.2.1-py3-none-any.whl", hash = "sha256:c56a26ced38c236f79e74af3ccce53772827cef5c3bce7cab33ff2060f756373"},
-    {file = "immutabledict-4.2.1.tar.gz", hash = "sha256:d91017248981c72eb66c8ff9834e99c2f53562346f23e7f51e7a5ebcf66a3bcc"},
 ]
 
 [[package]]
@@ -635,25 +589,6 @@ files = [
 ]
 
 [[package]]
-name = "networkx"
-version = "3.4.2"
-description = "Python package for creating and manipulating graphs and networks"
-optional = false
-python-versions = ">=3.10"
-files = [
-    {file = "networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f"},
-    {file = "networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1"},
-]
-
-[package.extras]
-default = ["matplotlib (>=3.7)", "numpy (>=1.24)", "pandas (>=2.0)", "scipy (>=1.10,!=1.11.0,!=1.11.1)"]
-developer = ["changelist (==0.5)", "mypy (>=1.1)", "pre-commit (>=3.2)", "rtoml"]
-doc = ["intersphinx-registry", "myst-nb (>=1.1)", "numpydoc (>=1.8.0)", "pillow (>=9.4)", "pydata-sphinx-theme (>=0.15)", "sphinx (>=7.3)", "sphinx-gallery (>=0.16)", "texext (>=0.6.7)"]
-example = ["cairocffi (>=1.7)", "contextily (>=1.6)", "igraph (>=0.11)", "momepy (>=0.7.2)", "osmnx (>=1.9)", "scikit-learn (>=1.5)", "seaborn (>=0.13)"]
-extra = ["lxml (>=4.6)", "pydot (>=3.0.1)", "pygraphviz (>=1.14)", "sympy (>=1.10)"]
-test = ["pytest (>=7.2)", "pytest-cov (>=4.0)"]
-
-[[package]]
 name = "nodeenv"
 version = "1.9.1"
 description = "Node.js virtual environment builder"
@@ -736,29 +671,6 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
-name = "puyapy"
-version = "4.4.4"
-description = "An optimising compiler for Algorand Python"
-optional = false
-python-versions = "<4.0,>=3.12"
-files = [
-    {file = "puyapy-4.4.4-py3-none-any.whl", hash = "sha256:743bf8bf10189f4254b8feed78b6e378dc36422857e2af771bfcf26954cb6aa5"},
-]
-
-[package.dependencies]
-attrs = ">=24.2.0,<25.0.0"
-cattrs = ">=24.1,<25.0"
-colorama = {version = ">=0.4.6,<0.5.0", markers = "sys_platform == \"win32\""}
-docstring-parser = ">=0.14.1"
-immutabledict = ">=4.2.0,<5.0.0"
-mypy_extensions = ">=1.0.0,<2.0.0"
-networkx = ">=3.4.2,<4.0.0"
-packaging = ">=24.0,<25.0"
-pycryptodomex = ">=3.6.0,<4"
-structlog = ">=24.1.0,<25.0.0"
-typing-extensions = ">=4.11.0,<5.0.0"
-
-[[package]]
 name = "pycodestyle"
 version = "2.11.1"
 description = "Python style guide checker"
@@ -767,47 +679,6 @@ python-versions = ">=3.8"
 files = [
     {file = "pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"},
     {file = "pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f"},
-]
-
-[[package]]
-name = "pycryptodomex"
-version = "3.20.0"
-description = "Cryptographic library for Python"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "pycryptodomex-3.20.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:645bd4ca6f543685d643dadf6a856cc382b654cc923460e3a10a49c1b3832aeb"},
-    {file = "pycryptodomex-3.20.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ff5c9a67f8a4fba4aed887216e32cbc48f2a6fb2673bb10a99e43be463e15913"},
-    {file = "pycryptodomex-3.20.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:8ee606964553c1a0bc74057dd8782a37d1c2bc0f01b83193b6f8bb14523b877b"},
-    {file = "pycryptodomex-3.20.0-cp27-cp27m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7805830e0c56d88f4d491fa5ac640dfc894c5ec570d1ece6ed1546e9df2e98d6"},
-    {file = "pycryptodomex-3.20.0-cp27-cp27m-musllinux_1_1_aarch64.whl", hash = "sha256:bc3ee1b4d97081260d92ae813a83de4d2653206967c4a0a017580f8b9548ddbc"},
-    {file = "pycryptodomex-3.20.0-cp27-cp27m-win32.whl", hash = "sha256:8af1a451ff9e123d0d8bd5d5e60f8e3315c3a64f3cdd6bc853e26090e195cdc8"},
-    {file = "pycryptodomex-3.20.0-cp27-cp27m-win_amd64.whl", hash = "sha256:cbe71b6712429650e3883dc81286edb94c328ffcd24849accac0a4dbcc76958a"},
-    {file = "pycryptodomex-3.20.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:76bd15bb65c14900d98835fcd10f59e5e0435077431d3a394b60b15864fddd64"},
-    {file = "pycryptodomex-3.20.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:653b29b0819605fe0898829c8ad6400a6ccde096146730c2da54eede9b7b8baa"},
-    {file = "pycryptodomex-3.20.0-cp27-cp27mu-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62a5ec91388984909bb5398ea49ee61b68ecb579123694bffa172c3b0a107079"},
-    {file = "pycryptodomex-3.20.0-cp27-cp27mu-musllinux_1_1_aarch64.whl", hash = "sha256:108e5f1c1cd70ffce0b68739c75734437c919d2eaec8e85bffc2c8b4d2794305"},
-    {file = "pycryptodomex-3.20.0-cp35-abi3-macosx_10_9_universal2.whl", hash = "sha256:59af01efb011b0e8b686ba7758d59cf4a8263f9ad35911bfe3f416cee4f5c08c"},
-    {file = "pycryptodomex-3.20.0-cp35-abi3-macosx_10_9_x86_64.whl", hash = "sha256:82ee7696ed8eb9a82c7037f32ba9b7c59e51dda6f105b39f043b6ef293989cb3"},
-    {file = "pycryptodomex-3.20.0-cp35-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91852d4480a4537d169c29a9d104dda44094c78f1f5b67bca76c29a91042b623"},
-    {file = "pycryptodomex-3.20.0-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bca649483d5ed251d06daf25957f802e44e6bb6df2e8f218ae71968ff8f8edc4"},
-    {file = "pycryptodomex-3.20.0-cp35-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e186342cfcc3aafaad565cbd496060e5a614b441cacc3995ef0091115c1f6c5"},
-    {file = "pycryptodomex-3.20.0-cp35-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:25cd61e846aaab76d5791d006497134602a9e451e954833018161befc3b5b9ed"},
-    {file = "pycryptodomex-3.20.0-cp35-abi3-musllinux_1_1_i686.whl", hash = "sha256:9c682436c359b5ada67e882fec34689726a09c461efd75b6ea77b2403d5665b7"},
-    {file = "pycryptodomex-3.20.0-cp35-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:7a7a8f33a1f1fb762ede6cc9cbab8f2a9ba13b196bfaf7bc6f0b39d2ba315a43"},
-    {file = "pycryptodomex-3.20.0-cp35-abi3-win32.whl", hash = "sha256:c39778fd0548d78917b61f03c1fa8bfda6cfcf98c767decf360945fe6f97461e"},
-    {file = "pycryptodomex-3.20.0-cp35-abi3-win_amd64.whl", hash = "sha256:2a47bcc478741b71273b917232f521fd5704ab4b25d301669879e7273d3586cc"},
-    {file = "pycryptodomex-3.20.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:1be97461c439a6af4fe1cf8bf6ca5936d3db252737d2f379cc6b2e394e12a458"},
-    {file = "pycryptodomex-3.20.0-pp27-pypy_73-win32.whl", hash = "sha256:19764605feea0df966445d46533729b645033f134baeb3ea26ad518c9fdf212c"},
-    {file = "pycryptodomex-3.20.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:f2e497413560e03421484189a6b65e33fe800d3bd75590e6d78d4dfdb7accf3b"},
-    {file = "pycryptodomex-3.20.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e48217c7901edd95f9f097feaa0388da215ed14ce2ece803d3f300b4e694abea"},
-    {file = "pycryptodomex-3.20.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d00fe8596e1cc46b44bf3907354e9377aa030ec4cd04afbbf6e899fc1e2a7781"},
-    {file = "pycryptodomex-3.20.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:88afd7a3af7ddddd42c2deda43d53d3dfc016c11327d0915f90ca34ebda91499"},
-    {file = "pycryptodomex-3.20.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:d3584623e68a5064a04748fb6d76117a21a7cb5eaba20608a41c7d0c61721794"},
-    {file = "pycryptodomex-3.20.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0daad007b685db36d977f9de73f61f8da2a7104e20aca3effd30752fd56f73e1"},
-    {file = "pycryptodomex-3.20.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5dcac11031a71348faaed1f403a0debd56bf5404232284cf8c761ff918886ebc"},
-    {file = "pycryptodomex-3.20.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:69138068268127cd605e03438312d8f271135a33140e2742b417d027a0539427"},
-    {file = "pycryptodomex-3.20.0.tar.gz", hash = "sha256:7a710b79baddd65b806402e14766c721aee8fb83381769c27920f26476276c1e"},
 ]
 
 [[package]]
@@ -965,23 +836,6 @@ files = [
 ]
 
 [[package]]
-name = "structlog"
-version = "24.4.0"
-description = "Structured Logging for Python"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "structlog-24.4.0-py3-none-any.whl", hash = "sha256:597f61e80a91cc0749a9fd2a098ed76715a1c8a01f73e336b746504d1aad7610"},
-    {file = "structlog-24.4.0.tar.gz", hash = "sha256:b27bfecede327a6d2da5fbc96bd859f114ecc398a6389d664f62085ee7ae6fc4"},
-]
-
-[package.extras]
-dev = ["freezegun (>=0.2.8)", "mypy (>=1.4)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=0.17)", "rich", "simplejson", "twisted"]
-docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "sphinxext-opengraph", "twisted"]
-tests = ["freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=0.17)", "simplejson"]
-typing = ["mypy (>=1.4)", "rich", "twisted"]
-
-[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20241230"
 description = "Typing stubs for PyYAML"
@@ -1129,4 +983,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "d5469acae008d45cb00a4cef7b5b64e53e3223632dc0aa8f32a8fd527cd3b0b0"
+content-hash = "37838963b760cb83f951b4eeaedfa6b21f31c3593f1c30ab9cbf7c4c7aa7cfce"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ mypy = "^1.15.0"
 pre-commit = "^4.0.1"
 types-pyyaml = "^6.0.12.9"
 pytest-xdist = "^3.3.1"
-puyapy = "^4.4.4"
 
 [build-system]
 requires = ["poetry-core"]

--- a/template_content/.algokit.toml.jinja
+++ b/template_content/.algokit.toml.jinja
@@ -1,5 +1,5 @@
 [algokit]
-min_version = "v2.0.0"
+min_version = "v2.6.0"
 
 [generate.smart-contract]
 description = "Generate a new smart contract for existing project"

--- a/template_content/README.md.jinja
+++ b/template_content/README.md.jinja
@@ -23,7 +23,6 @@ Ensure the following pre-requisites are installed and properly configured:
 
 - **Docker**: Required for running a local Algorand network.
 - **AlgoKit CLI**: Essential for project setup and operations. Verify installation with `algokit --version`, expecting `2.5.0` or later.
-- **Puya Compiler**: Can be installed from PyPi by running `pipx install puyapy`. Verify installation with `puyapy --version`, expecting `4.4.4` or later.
 
 #### 3. Bootstrap Your Local Environment
 Run the following commands within the project folder:

--- a/template_content/package.json.jinja
+++ b/template_content/package.json.jinja
@@ -34,7 +34,7 @@
     "@algorandfoundation/algokit-client-generator": "^4.0.9",
     "@algorandfoundation/algokit-utils": "^8.2.2",
     "@algorandfoundation/algokit-utils-debug": "^1.0.3",
-    "@algorandfoundation/puya-ts": "^1.0.0-beta.47",
+    "@algorandfoundation/puya-ts": "^1.0.0-beta.50",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
     "algosdk": "^3.0.0",
@@ -52,7 +52,7 @@
     {%- endif %}
     "ts-node-dev": "^2.0.0",
     {%- if use_vitest  %}
-    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.29",
+    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.30",
     "vitest": "^2.1.8",
     "@vitest/coverage-v8": "^2.1.8",
     {%- endif %}

--- a/template_content/package.json.jinja
+++ b/template_content/package.json.jinja
@@ -4,7 +4,7 @@
   "description": "Smart contract deployer",
   "main": "smart_contracts/index.ts",
   "scripts": {
-    "build": "puya-ts build smart_contracts --output-source-map --out-dir artifacts && algokit generate client smart_contracts/artifacts --output {app_spec_dir}/{contract_name}Client.ts",
+    "build": "algokit compile ts smart_contracts --output-source-map --out-dir artifacts && algokit generate client smart_contracts/artifacts --output {app_spec_dir}/{contract_name}Client.ts",
     "deploy": "ts-node-dev --transpile-only --watch .env -r dotenv/config smart_contracts/index.ts",
     "deploy:ci": "ts-node --transpile-only -r dotenv/config smart_contracts/index.ts",
     {%- if use_linter  %}
@@ -28,13 +28,13 @@
     "npm": ">=9.0"
   },
   "dependencies": {
-    "@algorandfoundation/algorand-typescript": "^1.0.0-beta.20"
+    "@algorandfoundation/algorand-typescript": "^1.0.0-beta.25"
   },
   "devDependencies": {
-    "@algorandfoundation/algokit-client-generator": "^4.0.8",
-    "@algorandfoundation/algokit-utils": "^8.2.1",
+    "@algorandfoundation/algokit-client-generator": "^4.0.9",
+    "@algorandfoundation/algokit-utils": "^8.2.2",
     "@algorandfoundation/algokit-utils-debug": "^1.0.3",
-    "@algorandfoundation/puya-ts": "^1.0.0-beta.34",
+    "@algorandfoundation/puya-ts": "^1.0.0-beta.47",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
     "algosdk": "^3.0.0",
@@ -52,7 +52,7 @@
     {%- endif %}
     "ts-node-dev": "^2.0.0",
     {%- if use_vitest  %}
-    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.27",
+    "@algorandfoundation/algorand-typescript-testing": "^1.0.0-beta.29",
     "vitest": "^2.1.8",
     "@vitest/coverage-v8": "^2.1.8",
     {%- endif %}

--- a/template_content/{% if use_github_actions %}.github{% endif %}/workflows/{% include pathjoin('includes', 'project_name_kebab.jinja') %}-ci.yaml.jinja
+++ b/template_content/{% if use_github_actions %}.github{% endif %}/workflows/{% include pathjoin('includes', 'project_name_kebab.jinja') %}-ci.yaml.jinja
@@ -29,9 +29,6 @@ jobs:
       - name: Install algokit
         run: pipx install algokit
 
-      - name: Install Puya compiler
-        run: pipx install puyapy
-
       - name: Start LocalNet
         run: algokit localnet start
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -22,7 +22,7 @@ config_path = Path(__file__).parent.parent / "pyproject.toml"
 BUILD_ARGS = ["algokit", "project", "run", "build"]
 TEST_ARGS = ["algokit", "project", "run", "test"]
 LINT_ARGS = ["algokit", "project", "run", "lint"]
-BOOTSTRAP_ARGS = ["algokit", "project", "bootstrap", "all"]
+BOOTSTRAP_ARGS = ["algokit", "project", "bootstrap", "all", "--no-ci"]
 
 
 def _load_copier_yaml(path: Path) -> dict[str, str | bool | dict]:


### PR DESCRIPTION
This template now depends on `algokit compile ts` and therefore will need to be merged after the CLI includes this support.