### PR TITLE
feat: use puya-ts alpha

### DIFF
--- a/examples/production/package.json
+++ b/examples/production/package.json
@@ -20,13 +20,13 @@
     "npm": ">=9.0"
   },
   "dependencies": {
-    "@algorandfoundation/algorand-typescript": "~1.0.0-alpha.80 <1.0.0"
+    "@algorandfoundation/algorand-typescript": "1.0.0-alpha.80"
   },
   "devDependencies": {
     "@algorandfoundation/algokit-client-generator": "^6.0.0",
     "@algorandfoundation/algokit-utils": "^9.0.0",
     "@algorandfoundation/algokit-utils-debug": "^1.0.4",
-    "@algorandfoundation/puya-ts": "~1.0.0-alpha.80 <1.0.0",
+    "@algorandfoundation/puya-ts": "1.0.0-alpha.80",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
     "algosdk": "^3.0.0",
@@ -37,7 +37,7 @@
     "typescript-eslint": "^8.19.1",
     "prettier": "^3.4.2",
     "ts-node-dev": "^2.0.0",
-    "@algorandfoundation/algorand-typescript-testing": "~1.0.0-alpha.80 <1.0.0",
+    "@algorandfoundation/algorand-typescript-testing": "1.0.0-alpha.80",
     "vitest": "^2.1.8",
     "@vitest/coverage-v8": "^2.1.8",
     "typescript": "^5.7.3"

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -14,13 +14,13 @@
     "npm": ">=9.0"
   },
   "dependencies": {
-    "@algorandfoundation/algorand-typescript": "~1.0.0-alpha.80 <1.0.0"
+    "@algorandfoundation/algorand-typescript": "1.0.0-alpha.80"
   },
   "devDependencies": {
     "@algorandfoundation/algokit-client-generator": "^6.0.0",
     "@algorandfoundation/algokit-utils": "^9.0.0",
     "@algorandfoundation/algokit-utils-debug": "^1.0.4",
-    "@algorandfoundation/puya-ts": "~1.0.0-alpha.80 <1.0.0",
+    "@algorandfoundation/puya-ts": "1.0.0-alpha.80",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
     "algosdk": "^3.0.0",

--- a/template_content/package.json.jinja
+++ b/template_content/package.json.jinja
@@ -28,13 +28,13 @@
     "npm": ">=9.0"
   },
   "dependencies": {
-    "@algorandfoundation/algorand-typescript": "~1.0.0-alpha.80 <1.0.0"
+    "@algorandfoundation/algorand-typescript": "1.0.0-alpha.80"
   },
   "devDependencies": {
     "@algorandfoundation/algokit-client-generator": "^6.0.0",
     "@algorandfoundation/algokit-utils": "^9.0.0",
     "@algorandfoundation/algokit-utils-debug": "^1.0.4",
-    "@algorandfoundation/puya-ts": "~1.0.0-alpha.80 <1.0.0",
+    "@algorandfoundation/puya-ts": "1.0.0-alpha.80",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
     "algosdk": "^3.0.0",
@@ -52,7 +52,7 @@
     {%- endif %}
     "ts-node-dev": "^2.0.0",
     {%- if use_vitest  %}
-    "@algorandfoundation/algorand-typescript-testing": "~1.0.0-alpha.80 <1.0.0",
+    "@algorandfoundation/algorand-typescript-testing": "1.0.0-alpha.80",
     "vitest": "^2.1.8",
     "@vitest/coverage-v8": "^2.1.8",
     {%- endif %}


### PR DESCRIPTION
Changes the version used by the template to alpha. 

Some context: we are at the EasyA harvard hackathon and want the new inits to use the latest puya TS version since this is what we are going over in the workshop

We felt like updating the template is preferable to doing a beta release so existing template instantiations aren't affected until we are ready for a beta release. Since we are close to release, this seems like a reasonable compromise