### PR TITLE
chore: update to the latest algosdk decoupled packages

### DIFF
--- a/examples/production/package.json
+++ b/examples/production/package.json
@@ -23,9 +23,9 @@
     "@algorandfoundation/algorand-typescript": "^1.0.1"
   },
   "devDependencies": {
-    "@algorandfoundation/algokit-client-generator": "^7.0.0-alpha.2",
-    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.20",
-    "@algorandfoundation/algokit-utils-debug": "^2.0.0-alpha.1",
+    "@algorandfoundation/algokit-client-generator": "^7.0.0-alpha.5",
+    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.27",
+    "@algorandfoundation/algokit-utils-debug": "^2.0.0-alpha.2",
     "@algorandfoundation/puya-ts": "^1.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",

--- a/examples/production/package.json
+++ b/examples/production/package.json
@@ -23,13 +23,12 @@
     "@algorandfoundation/algorand-typescript": "^1.0.1"
   },
   "devDependencies": {
-    "@algorandfoundation/algokit-client-generator": "^6.0.0",
-    "@algorandfoundation/algokit-utils": "^9.0.0",
-    "@algorandfoundation/algokit-utils-debug": "^1.0.4",
+    "@algorandfoundation/algokit-client-generator": "^7.0.0-alpha.2",
+    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.20",
+    "@algorandfoundation/algokit-utils-debug": "^2.0.0-alpha.1",
     "@algorandfoundation/puya-ts": "^1.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
-    "algosdk": "^3.0.0",
     "better-npm-audit": "^3.11.0",
     "dotenv": "^16.4.7",
     "eslint": "^9.18.0",

--- a/examples/production/package.json
+++ b/examples/production/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@algorandfoundation/algokit-client-generator": "^7.0.0-alpha.5",
-    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.27",
+    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.32",
     "@algorandfoundation/algokit-utils-debug": "^2.0.0-alpha.2",
     "@algorandfoundation/puya-ts": "^1.0.1",
     "@rollup/plugin-typescript": "^12.1.2",

--- a/examples/production/smart_contracts/hello_world/contract.e2e.spec.ts
+++ b/examples/production/smart_contracts/hello_world/contract.e2e.spec.ts
@@ -1,7 +1,6 @@
-import { Config } from '@algorandfoundation/algokit-utils'
+import { Config, Address } from '@algorandfoundation/algokit-utils'
 import { registerDebugEventHandlers } from '@algorandfoundation/algokit-utils-debug'
 import { algorandFixture } from '@algorandfoundation/algokit-utils/testing'
-import { Address } from 'algosdk'
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { HelloWorldFactory } from '../artifacts/hello_world/HelloWorldClient'
 

--- a/examples/production/smart_contracts/index.ts
+++ b/examples/production/smart_contracts/index.ts
@@ -1,6 +1,6 @@
 import { Config } from '@algorandfoundation/algokit-utils'
 import { registerDebugEventHandlers } from '@algorandfoundation/algokit-utils-debug'
-import { consoleLogger } from '@algorandfoundation/algokit-utils/types/logging'
+import { consoleLogger } from '@algorandfoundation/algokit-utils/logging'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -17,13 +17,12 @@
     "@algorandfoundation/algorand-typescript": "^1.0.1"
   },
   "devDependencies": {
-    "@algorandfoundation/algokit-client-generator": "^6.0.0",
-    "@algorandfoundation/algokit-utils": "^9.0.0",
-    "@algorandfoundation/algokit-utils-debug": "^1.0.4",
+    "@algorandfoundation/algokit-client-generator": "^7.0.0-alpha.2",
+    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.20",
+    "@algorandfoundation/algokit-utils-debug": "^2.0.0-alpha.1",
     "@algorandfoundation/puya-ts": "^1.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
-    "algosdk": "^3.0.0",
     "dotenv": "^16.4.7",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.7.3"

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@algorandfoundation/algokit-client-generator": "^7.0.0-alpha.5",
-    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.27",
+    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.32",
     "@algorandfoundation/algokit-utils-debug": "^2.0.0-alpha.2",
     "@algorandfoundation/puya-ts": "^1.0.1",
     "@rollup/plugin-typescript": "^12.1.2",

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -17,9 +17,9 @@
     "@algorandfoundation/algorand-typescript": "^1.0.1"
   },
   "devDependencies": {
-    "@algorandfoundation/algokit-client-generator": "^7.0.0-alpha.2",
-    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.20",
-    "@algorandfoundation/algokit-utils-debug": "^2.0.0-alpha.1",
+    "@algorandfoundation/algokit-client-generator": "^7.0.0-alpha.5",
+    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.27",
+    "@algorandfoundation/algokit-utils-debug": "^2.0.0-alpha.2",
     "@algorandfoundation/puya-ts": "^1.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",

--- a/examples/starter/smart_contracts/index.ts
+++ b/examples/starter/smart_contracts/index.ts
@@ -1,6 +1,6 @@
 import { Config } from '@algorandfoundation/algokit-utils'
 import { registerDebugEventHandlers } from '@algorandfoundation/algokit-utils-debug'
-import { consoleLogger } from '@algorandfoundation/algokit-utils/types/logging'
+import { consoleLogger } from '@algorandfoundation/algokit-utils/logging'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 

--- a/template_content/.algokit/generators/create_contract/smart_contracts/{% raw %}{{ contract_name }}{% endraw %}/{% raw %}{% if include_tests %}contract.e2e.spec.ts{% endif %}.j2{% endraw %}
+++ b/template_content/.algokit/generators/create_contract/smart_contracts/{% raw %}{{ contract_name }}{% endraw %}/{% raw %}{% if include_tests %}contract.e2e.spec.ts{% endif %}.j2{% endraw %}
@@ -1,6 +1,5 @@
-import { Config } from '@algorandfoundation/algokit-utils'
+import { Config, Address } from '@algorandfoundation/algokit-utils'
 import { algorandFixture } from '@algorandfoundation/algokit-utils/testing'
-import { Address } from 'algosdk'
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { {{ contract_name.split('_')|map('capitalize')|join }}Factory } from '../artifacts/{{ contract_name }}/{{ contract_name.split('_')|map('capitalize')|join }}Client'
 

--- a/template_content/package.json.jinja
+++ b/template_content/package.json.jinja
@@ -31,9 +31,9 @@
     "@algorandfoundation/algorand-typescript": "^1.0.1"
   },
   "devDependencies": {
-    "@algorandfoundation/algokit-client-generator": "^7.0.0-alpha.2",
-    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.20",
-    "@algorandfoundation/algokit-utils-debug": "^2.0.0-alpha.1",
+    "@algorandfoundation/algokit-client-generator": "^7.0.0-alpha.5",
+    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.27",
+    "@algorandfoundation/algokit-utils-debug": "^2.0.0-alpha.2",
     "@algorandfoundation/puya-ts": "^1.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",

--- a/template_content/package.json.jinja
+++ b/template_content/package.json.jinja
@@ -31,13 +31,12 @@
     "@algorandfoundation/algorand-typescript": "^1.0.1"
   },
   "devDependencies": {
-    "@algorandfoundation/algokit-client-generator": "^6.0.0",
-    "@algorandfoundation/algokit-utils": "^9.0.0",
-    "@algorandfoundation/algokit-utils-debug": "^1.0.4",
+    "@algorandfoundation/algokit-client-generator": "^7.0.0-alpha.2",
+    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.20",
+    "@algorandfoundation/algokit-utils-debug": "^2.0.0-alpha.1",
     "@algorandfoundation/puya-ts": "^1.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
-    "algosdk": "^3.0.0",
     {%- if use_audit  %}
     "better-npm-audit": "^3.11.0",
     {%- endif %}

--- a/template_content/package.json.jinja
+++ b/template_content/package.json.jinja
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@algorandfoundation/algokit-client-generator": "^7.0.0-alpha.5",
-    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.27",
+    "@algorandfoundation/algokit-utils": "^10.0.0-alpha.32",
     "@algorandfoundation/algokit-utils-debug": "^2.0.0-alpha.2",
     "@algorandfoundation/puya-ts": "^1.0.1",
     "@rollup/plugin-typescript": "^12.1.2",

--- a/template_content/smart_contracts/index.ts
+++ b/template_content/smart_contracts/index.ts
@@ -1,6 +1,6 @@
 import { Config } from '@algorandfoundation/algokit-utils'
 import { registerDebugEventHandlers } from '@algorandfoundation/algokit-utils-debug'
-import { consoleLogger } from '@algorandfoundation/algokit-utils/types/logging'
+import { consoleLogger } from '@algorandfoundation/algokit-utils/logging'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 

--- a/template_content/smart_contracts/{{ contract_name }}/{% if use_vitest %}contract.e2e.spec.ts{% endif %}.jinja
+++ b/template_content/smart_contracts/{{ contract_name }}/{% if use_vitest %}contract.e2e.spec.ts{% endif %}.jinja
@@ -1,7 +1,6 @@
-import { Config } from '@algorandfoundation/algokit-utils'
+import { Config, Address } from '@algorandfoundation/algokit-utils'
 import { registerDebugEventHandlers } from '@algorandfoundation/algokit-utils-debug'
 import { algorandFixture } from '@algorandfoundation/algokit-utils/testing'
-import { Address } from 'algosdk'
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { {{ contract_name.split('_')|map('capitalize')|join }}Factory } from '../artifacts/{{ contract_name }}/{{ contract_name.split('_')|map('capitalize')|join }}Client'
 


### PR DESCRIPTION
Before merging, we'll need to update the alpha versions of the package to non pre-released versions.