### PR TITLE
fix: add @types/node to resolve type errors after fresh init

### DIFF
--- a/examples/production/package.json
+++ b/examples/production/package.json
@@ -29,6 +29,7 @@
     "@algorandfoundation/puya-ts": "^1.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
+    "@types/node": "^22.0.0",
     "algosdk": "^3.0.0",
     "better-npm-audit": "^3.11.0",
     "dotenv": "^16.4.7",

--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -23,6 +23,7 @@
     "@algorandfoundation/puya-ts": "^1.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
+    "@types/node": "^22.0.0",
     "algosdk": "^3.0.0",
     "dotenv": "^16.4.7",
     "ts-node-dev": "^2.0.0",

--- a/template_content/package.json.jinja
+++ b/template_content/package.json.jinja
@@ -37,6 +37,7 @@
     "@algorandfoundation/puya-ts": "^1.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node22": "^22.0.0",
+    "@types/node": "^22.0.0",
     "algosdk": "^3.0.0",
     {%- if use_audit  %}
     "better-npm-audit": "^3.11.0",


### PR DESCRIPTION
## Summary
- Adds `@types/node` (`^22.0.0`) to template devDependencies to resolve TypeScript type errors on freshly initialized projects
- The template uses `node:fs`, `node:path`, `__dirname`, and `process` in `smart_contracts/index.ts` but was missing the Node.js type definitions
- Updates both `starter` and `production` example outputs to match

Closes #45

## Test plan
- [ ] Initialize a fresh project with `algokit init` using the TypeScript template
- [ ] Verify no type errors in `smart_contracts/index.ts`
- [ ] Run `npm run check-types` to confirm clean TypeScript compilation
- [ ] @0xLeif review

🤖 Generated with [Claude Code](https://claude.com/claude-code)